### PR TITLE
git ignore 수정 및 env.local 추가

### DIFF
--- a/fe/packages/chromeside-board/.env.local
+++ b/fe/packages/chromeside-board/.env.local
@@ -1,0 +1,1 @@
+VITE_WSS_URL=ws://localhost:1234

--- a/fe/packages/chromeside-board/.gitignore
+++ b/fe/packages/chromeside-board/.gitignore
@@ -10,7 +10,6 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
-*.local
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
ignore 되면 explorer view에 회색으로 표시 되길래, env.local은 회색이 아니라 ignore 되지 않은 줄 알았는데 
<img width="243" alt="image" src="https://user-images.githubusercontent.com/23169601/236927803-b0314dec-57d7-4ceb-8064-4d44fa38b017.png">  

.gitignore 에 `*.local`이 포함되어있었네요 ㅠㅠ   

@yunju-choi 님 감사합니다 👍 